### PR TITLE
Adding Enabled Field and Remove Schedule Config

### DIFF
--- a/qa-khoros-connector/km/connectors/khoros_boardsConnector.json
+++ b/qa-khoros-connector/km/connectors/khoros_boardsConnector.json
@@ -7,7 +7,8 @@
     "sourceConfig": {
       "apiPushConfig": {
         "app": "241765",
-        "dataFormat": "JSON"
+        "dataFormat": "JSON",
+        "enabled": true
       }
     },
     "baseSelector": {
@@ -99,9 +100,5 @@
       "header": "Category ID",
       "subfieldPath": []
     }
-  ],
-  "scheduleConfig": {
-    "useSourceSchedule": true,
-    "runMode": "DEFAULT"
-  }
+  ]
 }

--- a/qa-khoros-connector/km/connectors/khoros_categoriesConnector.json
+++ b/qa-khoros-connector/km/connectors/khoros_categoriesConnector.json
@@ -7,7 +7,8 @@
     "sourceConfig": {
       "apiPushConfig": {
         "app": "241765",
-        "dataFormat": "JSON"
+        "dataFormat": "JSON",
+        "enabled": true
       }
     },
     "baseSelector": {
@@ -101,9 +102,5 @@
       "header": "Creation Date",
       "subfieldPath": []
     }
-  ],
-  "scheduleConfig": {
-    "useSourceSchedule": true,
-    "runMode": "DEFAULT"
-  }
+  ]
 }

--- a/qa-khoros-connector/km/connectors/khoros_conversationsConnector.json
+++ b/qa-khoros-connector/km/connectors/khoros_conversationsConnector.json
@@ -7,7 +7,8 @@
     "sourceConfig": {
       "apiPushConfig": {
         "app": "241765",
-        "dataFormat": "JSON"
+        "dataFormat": "JSON",
+        "enabled": true
       }
     },
     "baseSelector": {
@@ -408,9 +409,5 @@
         }
       ]
     }
-  ],
-  "scheduleConfig": {
-    "useSourceSchedule": true,
-    "runMode": "DEFAULT"
-  }
+  ]
 }

--- a/qa-khoros-connector/km/connectors/khoros_usersConnector.json
+++ b/qa-khoros-connector/km/connectors/khoros_usersConnector.json
@@ -7,7 +7,8 @@
     "sourceConfig": {
       "apiPushConfig": {
         "app": "241765",
-        "dataFormat": "JSON"
+        "dataFormat": "JSON",
+        "enabled": true
       }
     },
     "baseSelector": {
@@ -93,9 +94,5 @@
       "header": "Last Name",
       "subfieldPath": []
     }
-  ],
-  "scheduleConfig": {
-    "useSourceSchedule": true,
-    "runMode": "DEFAULT"
-  }
+  ]
 }


### PR DESCRIPTION
Schedule Configurations will soon be removed from all push connectors
with added validation preventing it. Adding enabled flag which will
be used when pushing data - the enabled flag uses the boolean from
use source schedule
